### PR TITLE
Refactored event handler in `statusStripStatistic.MouseLeave`

### DIFF
--- a/NumericListGeneratorForm.Designer.cs
+++ b/NumericListGeneratorForm.Designer.cs
@@ -513,7 +513,7 @@ namespace Numeric_List_Generator
 			statusStripStatistic.Text = "statusStripStatistic";
 			toolTip.SetToolTip(statusStripStatistic, "Statusbar für statistische Angaben");
 			statusStripStatistic.Enter += SetStatusBar_Enter;
-			statusStripStatistic.Leave += SetStatusBar_Enter;
+			statusStripStatistic.Leave += ClearStatusBar_Leave;
 			statusStripStatistic.MouseEnter += SetStatusBar_Enter;
 			statusStripStatistic.MouseLeave += ClearStatusBar_Leave;
 			// 


### PR DESCRIPTION
This PR corrects the `statusStripStatistic` focus/hover behavior in the WinForms UI by wiring the `Leave` event to the status-bar clearing handler, aligning it with the existing `MouseLeave` behavior.

Changes:

- Updated `statusStripStatistic.Leave` to call `ClearStatusBar_Leave` (instead of `SetStatusBar_Enter`), so the status bar text is cleared when the control loses focus.
